### PR TITLE
Add timer on mainRunLoop instead of currentRunLoop

### DIFF
--- a/Darkly/LDThrottler.m
+++ b/Darkly/LDThrottler.m
@@ -76,7 +76,7 @@ const NSTimeInterval minDelayInterval = 1.0;
     NSDate *fireDate = [self.timerStartDate dateByAddingTimeInterval:delaySeconds];
 
     NSTimer *delayTimer = [[NSTimer alloc] initWithFireDate:fireDate interval:0 target:self selector:@selector(timerFired) userInfo:nil repeats:NO];
-    [[NSRunLoop currentRunLoop] addTimer:delayTimer forMode:NSDefaultRunLoopMode];
+    [[NSRunLoop mainRunLoop] addTimer:delayTimer forMode:NSDefaultRunLoopMode];
     return delayTimer;
 }
 


### PR DESCRIPTION
I'm using polling and noticed that calling LDClient start on the main thread would block on the network call.  I want to do something like

DispatchQueue.global(qos: DispatchQoS.QoSClass.default).async {
    LDClient.sharedInstance().start(config, with: userBuilder)
}

When I did that, I noticed that the timer wasn't firing - I guess the thread for the currentRunLoop was already gone.

This change seems to solve my problem.