### PR TITLE
Fix crash with findChangedFlagKeys and symmetricDifference

### DIFF
--- a/LaunchDarkly.podspec
+++ b/LaunchDarkly.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |ld|
 
   ld.name         = "LaunchDarkly"
-  ld.version      = "4.0.0"
+  ld.version      = "4.0.1"
   ld.summary      = "iOS SDK for LaunchDarkly"
 
   ld.description  = <<-DESC

--- a/LaunchDarkly/LaunchDarkly/Extensions/Dictionary.swift
+++ b/LaunchDarkly/LaunchDarkly/Extensions/Dictionary.swift
@@ -43,12 +43,20 @@ extension Dictionary where Key == String {
     }
 
     func symmetricDifference(_ other: [String: Any]) -> [String] {
-        let leftKeys: Set<String> = Set(self.keys)
-        let rightKeys: Set<String> = Set(other.keys)
+        var currentDictionary = [String: Any]()
+        self.forEach { (key, value) in
+            currentDictionary[key] = value
+        }
+        var otherDictionary = [String: Any]()
+        other.forEach { (key, value) in
+            otherDictionary[key] = value
+        }
+        let leftKeys: Set<String> = Set(currentDictionary.keys)
+        let rightKeys: Set<String> = Set(otherDictionary.keys)
         let differingKeys = leftKeys.symmetricDifference(rightKeys)
         let matchingKeys = leftKeys.intersection(rightKeys)
         let matchingKeysWithDifferentValues = matchingKeys.filter { (key) -> Bool in
-            !AnyComparer.isEqual(self[key], to: other[key])
+            !AnyComparer.isEqual(currentDictionary[key], to: otherDictionary[key])
         }
         return differingKeys.union(matchingKeysWithDifferentValues).sorted()
     }

--- a/LaunchDarkly/LaunchDarkly/Service Objects/FlagChangeNotifier.swift
+++ b/LaunchDarkly/LaunchDarkly/Service Objects/FlagChangeNotifier.swift
@@ -130,12 +130,20 @@ final class FlagChangeNotifier: FlagChangeNotifying {
     }
 
     private func findChangedFlagKeys(oldFlags: [LDFlagKey: FeatureFlag], newFlags: [LDFlagKey: FeatureFlag]) -> [LDFlagKey] {
-        return oldFlags.symmetricDifference(newFlags)     //symmetricDifference tests for equality, which includes version. Exclude version here.
+        var oldFlagsDictionary = [String: Any]()
+        oldFlags.forEach { (key, value) in
+            oldFlagsDictionary[key] = value
+        }
+        var newFlagsDictionary = [String: Any]()
+        newFlags.forEach { (key, value) in
+            newFlagsDictionary[key] = value
+        }
+        return oldFlagsDictionary.symmetricDifference(newFlagsDictionary)     //symmetricDifference tests for equality, which includes version. Exclude version here.
             .filter { (flagKey) in
-                guard let oldFeatureFlag = oldFlags[flagKey],
-                    let newFeatureFlag = newFlags[flagKey]
-                else {
-                    return true
+                guard let oldFeatureFlag = oldFlagsDictionary[flagKey] as? FeatureFlag,
+                    let newFeatureFlag = newFlagsDictionary[flagKey] as? FeatureFlag
+                    else {
+                        return true
                 }
                 return !oldFeatureFlag.matchesVariation(newFeatureFlag)
         }


### PR DESCRIPTION
## Background

We are seeing two bad crashes in the LaunchDarkly SDK in our app. The stacktraces are below:


```
Crashed: com.apple.main-thread
0  LaunchDarkly                   0x10247cf10 $ss17_dictionaryUpCastySDyq0_q1_GSDyxq_GSHRzSHR0_r2_lFSS_12LaunchDarkly11FeatureFlagVSSypTg5 + 168
1  LaunchDarkly                   0x10247fe64 $s12LaunchDarkly18FlagChangeNotifierC011findChangedC4Keys33_AAE936965AC09485A5BF28D82C960463LL8oldFlags03newP0SaySSGSDySSAA07FeatureC0VG_AKtFTf4nnd_n + 168
2  LaunchDarkly                   0x10247a9a0 $s12LaunchDarkly18FlagChangeNotifierC15notifyObservers4user8oldFlags0iC6SourceyAA6LDUserV_SDySSAA07FeatureC0VGAA011LDFlagValueK0OtF + 300
3  LaunchDarkly                   0x10247d388 $s12LaunchDarkly18FlagChangeNotifierCAA0cD9NotifyingA2aDP15notifyObservers4user8oldFlags0jC6SourceyAA6LDUserV_SDySSAA07FeatureC0VGAA011LDFlagValueL0OtFTW + 20
4  LaunchDarkly                   0x1024a2d60 $s12LaunchDarkly8LDClientC27updateCacheAndReportChanges33_14C52C04C80D938C2FE76924F7908AD1LL4user8oldFlags0R10FlagSourceyAA6LDUserV_SDySSAA07FeatureT0VGAA011LDFlagValueU0OtF + 456
5  LaunchDarkly                   0x1024a7a7c $s12LaunchDarkly8LDClientC18onFlagSyncComplete33_14C52C04C80D938C2FE76924F7908AD1LL6resultyAA0eF6ResultO_tFyycfU0_TA + 96
6  LaunchDarkly                   0x10248cc80 $s12LaunchDarkly9FlagStoreC06deleteC00E10Dictionary10completionySDySSypG_yycSgtFyycfU_6$deferL_yyFyycfU_TA + 28
7  LaunchDarkly                   0x102485600 $sIeg_IeyB_TR + 28
8  libdispatch.dylib              0x19befca38 _dispatch_call_block_and_release + 24
9  libdispatch.dylib              0x19befd7d4 _dispatch_client_callout + 16
10 libdispatch.dylib              0x19beab004 _dispatch_main_queue_callback_4CF$VARIANT$mp + 1068
11 CoreFoundation                 0x19c44dec0 __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__ + 12
12 CoreFoundation                 0x19c448df8 __CFRunLoopRun + 1924
13 CoreFoundation                 0x19c448354 CFRunLoopRunSpecific + 436
14 GraphicsServices               0x19e64879c GSEventRunModal + 104
15 UIKitCore                      0x1c89ffb68 UIApplicationMain + 212
16 *******                        0x100e95438 main (main.m:16)
17 libdyld.dylib                  0x19bf0e8e0 start + 4
```

```
Crashed: com.apple.main-thread
0  LaunchDarkly                   0x1060b5b34 $sShyShyxGqd__nc7ElementQyd__RszSTRd__lufCSS_SD4KeysVySS12LaunchDarkly11FeatureFlagV_GTg5 + 32
1  LaunchDarkly                   0x1060b57d4 $sSD12LaunchDarklySSRszrlE19symmetricDifferenceySaySSGSDySSypGFAA11FeatureFlagV_Tg5 + 60
2  LaunchDarkly                   0x1060d7e70 $s12LaunchDarkly18FlagChangeNotifierC011findChangedC4Keys33_AAE936965AC09485A5BF28D82C960463LL8oldFlags03newP0SaySSGSDySSAA07FeatureC0VG_AKtFTf4nnd_n + 180
3  LaunchDarkly                   0x1060d29a0 $s12LaunchDarkly18FlagChangeNotifierC15notifyObservers4user8oldFlags0iC6SourceyAA6LDUserV_SDySSAA07FeatureC0VGAA011LDFlagValueK0OtF + 300
4  LaunchDarkly                   0x1060d5388 $s12LaunchDarkly18FlagChangeNotifierCAA0cD9NotifyingA2aDP15notifyObservers4user8oldFlags0jC6SourceyAA6LDUserV_SDySSAA07FeatureC0VGAA011LDFlagValueL0OtFTW + 20
5  LaunchDarkly                   0x1060fad60 $s12LaunchDarkly8LDClientC27updateCacheAndReportChanges33_14C52C04C80D938C2FE76924F7908AD1LL4user8oldFlags0R10FlagSourceyAA6LDUserV_SDySSAA07FeatureT0VGAA011LDFlagValueU0OtF + 456
6  LaunchDarkly                   0x1060ffa7c $s12LaunchDarkly8LDClientC18onFlagSyncComplete33_14C52C04C80D938C2FE76924F7908AD1LL6resultyAA0eF6ResultO_tFyycfU0_TA + 96
7  LaunchDarkly                   0x1060e4c80 $s12LaunchDarkly9FlagStoreC06deleteC00E10Dictionary10completionySDySSypG_yycSgtFyycfU_6$deferL_yyFyycfU_TA + 28
8  LaunchDarkly                   0x1060dd600 $sIeg_IeyB_TR + 28
9  libdispatch.dylib              0x20293ca38 _dispatch_call_block_and_release + 24
10 libdispatch.dylib              0x20293d7d4 _dispatch_client_callout + 16
11 libdispatch.dylib              0x20291d9e4 _dispatch_main_queue_callback_4CF$VARIANT$armv81 + 1008
12 CoreFoundation                 0x202e8ec1c __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__ + 12
13 CoreFoundation                 0x202e89b54 __CFRunLoopRun + 1924
14 CoreFoundation                 0x202e890b0 CFRunLoopRunSpecific + 436
15 GraphicsServices               0x20508979c GSEventRunModal + 104
16 UIKitCore                      0x22f6f5978 UIApplicationMain + 212
17 *******                        0x104ad14c0 main (main.m:16)
18 libdyld.dylib                  0x20294e8e0 start + 4
```

These are the stacktraces we get from Crashlytics. I was unable to produce these crashes locally but my suspicion based on the stacktrace is that they are triggered when a feature flag is deleted on LaunchDarkly and the iOS client is updating its flags as a result.

For both crashes we are getting the following crash reason:
```
Crashed: com.apple.main-thread
EXC_BAD_ACCESS KERN_INVALID_ADDRESS 0x0000000000000000
```

## Potential Findings

This tells me that something in either `findChangedFlagKeys` or `symmetricDifference` is trying to access a deallocated object. I have included in this PR measures to mitigate against this.

## Version bump

I have also included in this PR a version bump in the podspec - I would like to respectfully ask that this change come with a version bump to the LaunchDarkly SDK as well as a push to the Cocoapods trunk so that we can take advantage of this fix as quickly as possible.