### PR TITLE
Prepare 4.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to the LaunchDarkly iOS SDK will be documented in this file.
 ### Multiple Environment clients
 Version 4.0.0 does not support multiple environments. If you use version `2.14.0` or later and set `LDConfig`'s `secondaryMobileKeys` you will not be able to migrate to version `4.0.0`. Multiple Environments will be added in a future release to the Swift SDK.
 
-## [4.0.1] - 2019-06-18
+## [4.1.0] - 2019-06-18
+### Change
+- Installs new `deviceModel` into `EnvironmentReporter` and renames old `deviceModel` to `deviceType`
+- use `CwSysCtl` for macos model
+
 ### Fixed
 - Fixed a concurrency bug that caused crashes in FlagStore.swift. This bug could surface during rapid updates to local flags.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ Version 4.0.0 does not support multiple environments. If you use version `2.14.0
 
 ## [4.1.0] - 2019-06-19
 ### Change
-- Installs new `deviceModel` into `EnvironmentReporter` and renames old `deviceModel` to `deviceType`
-- use `CwSysCtl` for macos model
+- Installs new `deviceModel` into `EnvironmentReporter` and renames old `deviceModel` to `deviceType`.
+- Updated MacOS model detection to use `CwSysCtl`.
 
 ### Fixed
 - Fixed a concurrency bug that caused crashes in FlagStore.swift. This bug could surface during rapid updates to local flags.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to the LaunchDarkly iOS SDK will be documented in this file.
 ### Multiple Environment clients
 Version 4.0.0 does not support multiple environments. If you use version `2.14.0` or later and set `LDConfig`'s `secondaryMobileKeys` you will not be able to migrate to version `4.0.0`. Multiple Environments will be added in a future release to the Swift SDK.
 
+## [4.0.1] - 2019-06-18
+### Fixed
+- Fixed a concurreny bug in FlagStore.swift
+
 ## [4.0.0] - 2019-04-18
 This is the non-beta first release of the Swift SDK. It follows the beta.3 release from 2019-03-07. Unlike previous Swift SDK releases, this release does not have a `3.0.0` companion tag.
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the LaunchDarkly iOS SDK will be documented in this file.
 ### Multiple Environment clients
 Version 4.0.0 does not support multiple environments. If you use version `2.14.0` or later and set `LDConfig`'s `secondaryMobileKeys` you will not be able to migrate to version `4.0.0`. Multiple Environments will be added in a future release to the Swift SDK.
 
-## [4.1.0] - 2019-06-18
+## [4.1.0] - 2019-06-19
 ### Change
 - Installs new `deviceModel` into `EnvironmentReporter` and renames old `deviceModel` to `deviceType`
 - use `CwSysCtl` for macos model

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Version 4.0.0 does not support multiple environments. If you use version `2.14.0
 
 ## [4.0.1] - 2019-06-18
 ### Fixed
-- Fixed a concurreny bug in FlagStore.swift
+- Fixed a concurrency bug that caused crashes in FlagStore.swift. This bug could surface during rapid updates to local flags.
 
 ## [4.0.0] - 2019-04-18
 This is the non-beta first release of the Swift SDK. It follows the beta.3 release from 2019-03-07. Unlike previous Swift SDK releases, this release does not have a `3.0.0` companion tag.

--- a/LaunchDarkly.podspec
+++ b/LaunchDarkly.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |ld|
 
   ld.name         = "LaunchDarkly"
-  ld.version      = "4.0.0"
+  ld.version      = "4.0.1"
   ld.summary      = "iOS SDK for LaunchDarkly"
 
   ld.description  = <<-DESC
@@ -25,7 +25,7 @@ Pod::Spec.new do |ld|
   ld.tvos.deployment_target    = "9.0"
   ld.osx.deployment_target     = "10.10"
 
-  ld.source       = { :git => "https://github.com/launchdarkly/ios-client-sdk.git", :tag => '4.0.0'}
+  ld.source       = { :git => "https://github.com/launchdarkly/ios-client-sdk.git", :tag => '4.0.1'}
 
   ld.source_files = "LaunchDarkly/LaunchDarkly/**/*.{h,m,swift}"
 

--- a/LaunchDarkly.podspec
+++ b/LaunchDarkly.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |ld|
 
   ld.name         = "LaunchDarkly"
-  ld.version      = "4.0.1"
+  ld.version      = "4.1.0"
   ld.summary      = "iOS SDK for LaunchDarkly"
 
   ld.description  = <<-DESC
@@ -25,7 +25,7 @@ Pod::Spec.new do |ld|
   ld.tvos.deployment_target    = "9.0"
   ld.osx.deployment_target     = "10.10"
 
-  ld.source       = { :git => "https://github.com/launchdarkly/ios-client-sdk.git", :tag => '4.0.1'}
+  ld.source       = { :git => "https://github.com/launchdarkly/ios-client-sdk.git", :tag => '4.1.0'}
 
   ld.source_files = "LaunchDarkly/LaunchDarkly/**/*.{h,m,swift}"
 

--- a/LaunchDarkly.xcodeproj/project.pbxproj
+++ b/LaunchDarkly.xcodeproj/project.pbxproj
@@ -1056,12 +1056,12 @@
 				TargetAttributes = {
 					831188372113A16900D77CB5 = {
 						CreatedOnToolsVersion = 9.2;
-						LastSwiftMigration = 1010;
+						LastSwiftMigration = 1020;
 						ProvisioningStyle = Automatic;
 					};
 					831EF33A20655D700001C643 = {
 						CreatedOnToolsVersion = 9.2;
-						LastSwiftMigration = 1010;
+						LastSwiftMigration = 1020;
 						ProvisioningStyle = Automatic;
 					};
 					8354EFC11F22491C00C05156 = {
@@ -1076,7 +1076,7 @@
 					};
 					83D9EC6A2062DBB7004D7FA6 = {
 						CreatedOnToolsVersion = 9.2;
-						LastSwiftMigration = 1010;
+						LastSwiftMigration = 1020;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -1696,7 +1696,7 @@
 				PRODUCT_NAME = LaunchDarkly_tvOS;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
@@ -1729,7 +1729,7 @@
 				PRODUCT_NAME = LaunchDarkly_tvOS;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
@@ -1762,7 +1762,7 @@
 				PRODUCT_NAME = LaunchDarkly_macOS;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -1793,7 +1793,7 @@
 				PRODUCT_NAME = LaunchDarkly_macOS;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -2056,7 +2056,7 @@
 				PRODUCT_NAME = LaunchDarkly_watchOS;
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
@@ -2093,7 +2093,7 @@
 				PRODUCT_NAME = LaunchDarkly_watchOS;
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};

--- a/LaunchDarkly/LaunchDarkly/Service Objects/FlagStore.swift
+++ b/LaunchDarkly/LaunchDarkly/Service Objects/FlagStore.swift
@@ -100,8 +100,12 @@ final class FlagStore: FlagMaintaining {
             }
 
             Log.debug(self.typeName(and: #function) + "succeeded. new flag: \(newFlag), " + "prior flag: \(String(describing: self.featureFlags[flagKey]))")
-            self.featureFlags[flagKey] = newFlag
-
+            var localFeatureFlags: [LDFlagKey: FeatureFlag] = [:]
+            self.featureFlags.forEach { key, value in
+                localFeatureFlags[key] = value
+            }
+            localFeatureFlags[flagKey] = newFlag
+            self.featureFlags = localFeatureFlags
         }
     }
     
@@ -136,7 +140,12 @@ final class FlagStore: FlagMaintaining {
             }
 
             Log.debug(self.typeName(and: #function) + "deleted flag with key: " + flagKey)
-            self.featureFlags.removeValue(forKey: flagKey)
+            var localFeatureFlags: [LDFlagKey: FeatureFlag] = [:]
+            self.featureFlags.forEach { key, value in
+                localFeatureFlags[key] = value
+            }
+            localFeatureFlags.removeValue(forKey: flagKey)
+            self.featureFlags = localFeatureFlags
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ $ gem install cocoapods
 ```ruby
 use_frameworks!
 target 'YourTargetName' do
-  pod 'LaunchDarkly', '4.0.0'
+  pod 'LaunchDarkly', '4.0.1'
 end
 ```
 
@@ -70,7 +70,7 @@ $ brew install carthage
 To integrate LaunchDarkly into your Xcode project using Carthage, specify it in your `Cartfile`:
 
 ```ogdl
-github "launchdarkly/ios-client-sdk" "4.0.0"
+github "launchdarkly/ios-client-sdk" "4.0.1"
 ```
 
 Run `carthage update` to build the framework. Optionally, specify the `--platform` to build only the frameworks that support your platform(s).

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ $ gem install cocoapods
 ```ruby
 use_frameworks!
 target 'YourTargetName' do
-  pod 'LaunchDarkly', '4.0.1'
+  pod 'LaunchDarkly', '4.1.0'
 end
 ```
 
@@ -70,7 +70,7 @@ $ brew install carthage
 To integrate LaunchDarkly into your Xcode project using Carthage, specify it in your `Cartfile`:
 
 ```ogdl
-github "launchdarkly/ios-client-sdk" "4.0.1"
+github "launchdarkly/ios-client-sdk" "4.1.0"
 ```
 
 Run `carthage update` to build the framework. Optionally, specify the `--platform` to build only the frameworks that support your platform(s).


### PR DESCRIPTION
## [4.1.0] - 2019-06-19
### Change
- Installs new `deviceModel` into `EnvironmentReporter` and renames old `deviceModel` to `deviceType`
- use `CwSysCtl` for macos model

### Fixed
- Fixed a concurrency bug that caused crashes in FlagStore.swift. This bug could surface during rapid updates to local flags.