### PR TITLE
Only import WatchKit if running on watchOS

### DIFF
--- a/LaunchDarkly/LaunchDarkly/Service Objects/EnvironmentReporter.swift
+++ b/LaunchDarkly/LaunchDarkly/Service Objects/EnvironmentReporter.swift
@@ -8,8 +8,9 @@
 
 import Foundation
 
-#if os(iOS) || os(watchOS)
+#if os(iOS)
 import UIKit
+#elseif os(watchOS)
 import WatchKit
 #elseif os(OSX)
 import AppKit


### PR DESCRIPTION
### Problem

In Xcode 11, you cannot import WatchKit on iOS simulators.

Error:
```
"WatchKit" is not available when building for iOS Simulator. Consider using `#if !os(iOS)` to conditionally import this framework.
```

### Solution

- Conditionally import WatchKit if running on watchOS


### Testing

- Passes Tests
- Runs on both Xcode 10.2 and Xcode 11