### PR TITLE
Fix stack overflow when comparing two nil [String:Any]? objects

### DIFF
--- a/LaunchDarkly/LaunchDarkly/Extensions/Dictionary.swift
+++ b/LaunchDarkly/LaunchDarkly/Extensions/Dictionary.swift
@@ -78,7 +78,11 @@ extension Optional where Wrapped == [String: Any] {
     public static func == (lhs: [String: Any]?, rhs: [String: Any]?) -> Bool {
         guard let lhs = lhs
         else {
-            return rhs == nil
+            guard let _ = rhs
+            else {
+                return true
+            }
+            return false
         }
         guard let rhs = rhs
         else {


### PR DESCRIPTION
* Bypass recursive call to `==` operator of `Optional<[String:Any]>` by using `guard` operator. See issue #186.