### PR TITLE
Fix build on Xcode 11

### DIFF
--- a/LaunchDarkly/LaunchDarkly/Service Objects/EnvironmentReporter.swift
+++ b/LaunchDarkly/LaunchDarkly/Service Objects/EnvironmentReporter.swift
@@ -8,7 +8,9 @@
 
 import Foundation
 
-#if os(iOS) || os(watchOS)
+#if os(iOS)
+import UIKit
+#elseif os(watchOS)
 import UIKit
 import WatchKit
 #elseif os(OSX)


### PR DESCRIPTION
I was getting this error when building on Xcode 11:

```
ios-client-sdk/LaunchDarkly/LaunchDarkly/Service Objects/EnvironmentReporter.swift:13:8: error: no such module 'WatchKit'
import WatchKit
       ^
```