### PR TITLE
fix: calling identify while backgrounded no longer results in permanent offline behavior

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,10 @@ gem 'jazzy', '0.15.4'
 # configuration, before it reads any source. Hold mustache below 1.1.3 until jazzy
 # accommodates the new signature.
 gem 'mustache', '< 1.1.3'
+
+# jazzy 0.15.4 (the latest release) builds its search index with
+# `JSON.generate(..., quirks_mode: true)`, and json 3.0 removed the `quirks_mode`
+# keyword, so a fresh bundle install crashes doc generation. jazzy's source has
+# already dropped the call but it is unreleased. Hold json below 3.0 until a jazzy
+# release includes the fix, then remove this.
+gem 'json', '< 3.0'

--- a/LaunchDarkly/LaunchDarkly/LDClient.swift
+++ b/LaunchDarkly/LaunchDarkly/LDClient.swift
@@ -96,7 +96,7 @@ public class LDClient {
 
      When offline, the SDK does not attempt to communicate with LaunchDarkly servers. Client apps can request feature flag values and set/change feature flag observers while offline. The SDK will collect events while offline.
 
-     The SDK protects itself from multiple rapid calls to setOnline(true) by enforcing an increasing delay (called *throttling*) each time setOnline(true) is called within a short time. The first time, the call proceeds normally. For each subsequent call the delay is enforced, and if waiting, increased to a maximum delay. When the delay has elapsed, the `setOnline(true)` will proceed, assuming that the client app has not called `setOnline(false)` during the delay. Therefore a call to setOnline(true) may not immediately result in the LDClient going online. Client app developers should consider this situation abnormal, and take steps to prevent the client app from making multiple rapid setOnline(true) calls. Calls to setOnline(false) are not throttled. Note that calls to `start(config: context: completion:)`, and setting the `config` or `context` can also call `setOnline(true)` under certain conditions. After the delay, the SDK resets and the client app can make a susequent call to setOnline(true) without being throttled.
+     The SDK protects itself from multiple rapid calls to setOnline(true) by enforcing an increasing delay (called *throttling*) each time setOnline(true) is called within a short time. The first time, the call proceeds normally. For each subsequent call the delay is enforced, and if waiting, increased to a maximum delay. When the delay has elapsed, the `setOnline(true)` will proceed, assuming that the client app has not called `setOnline(false)` during the delay. Therefore a call to setOnline(true) may not immediately result in the LDClient going online. Client app developers should consider this situation abnormal, and take steps to prevent the client app from making multiple rapid setOnline(true) calls. Calls to setOnline(false) are not throttled. Note that calls to `start(config: context: completion:)` can also call `setOnline(true)` under certain conditions. After the delay, the SDK resets and the client app can make a susequent call to setOnline(true) without being throttled.
 
      Client apps can set a completion closure called when the setOnline call completes. For unthrottled `setOnline(true)` and all `setOnline(false)` calls, the SDK will call the closure immediately on completion of this method. For throttled `setOnline(true)` calls, the SDK will call the closure after the throttling delay at the completion of the setOnline method.
 
@@ -318,12 +318,12 @@ public class LDClient {
 
      The client app can change the active `context` by calling identify with a new or updated LDContext. Client apps should follow [Apple's Privacy Policy](apple.com/legal/privacy) when collecting user information.
 
-    When a new context is set, the LDClient goes offline and sets the new context. If the client was online when the new context was set, it goes online again, subject to a throttling delay if in force (see `setOnline(_: completion:)` for details). A completion may be passed to the identify method to allow a client app to know when fresh flag values for the new context are ready.
+    When a new context is set, the LDClient replaces its connection to LaunchDarkly with one for the new context. The client's online state is unchanged. A completion may be passed to the identify method to allow a client app to know when fresh flag values for the new context are ready; when the client is offline, or backgrounded where background updates are unsupported, the completion is called immediately without fresh values.
 
     Note: The `completion` closure is invoked on the main thread.
 
     - parameter context: The LDContext set with the desired context.
-     - parameter completion: Closure called when the embedded `setOnlineIdentify` call completes, subject to throttling delays. (Optional)
+     - parameter completion: Closure called when the identify completes: when the client is online, once fresh flag values for the new context are ready; when offline or backgrounded, immediately. (Optional)
     */
     @available(*, deprecated, message: "Use LDClient.identify(context: completion:) with non-optional completion parameter")
     public func identify(context: LDContext, completion: (() -> Void)? = nil) {
@@ -343,7 +343,7 @@ public class LDClient {
 
      The client app can change the active `context` by calling identify with a new or updated LDContext. Client apps should follow [Apple's Privacy Policy](apple.com/legal/privacy) when collecting user information.
 
-     When a new context is set, the LDClient goes offline and sets the new context. If the client was online when the new context was set, it goes online again, subject to a throttling delay if in force (see `setOnline(_: completion:)` for details). A completion may be passed to the identify method to allow a client app to know when fresh flag values for the new context are ready.
+     When a new context is set, the LDClient replaces its connection to LaunchDarkly with one for the new context. The client's online state is unchanged. A completion may be passed to the identify method to allow a client app to know when fresh flag values for the new context are ready; when the client is offline, or backgrounded where background updates are unsupported, the completion is called immediately without fresh values.
 
     While only a single identify request can be active at a time, consumers of this SDK can call this method multiple times. To prevent unnecessary network traffic, these requests are placed
     into a sheddable queue. Identify requests will be shed if 1) an existing identify request is in flight, and 2) a third identify has been requested which can be replace the one being shed.
@@ -351,7 +351,7 @@ public class LDClient {
     Note: The `completion` closure is invoked on the main thread.
 
     - parameter context: The LDContext set with the desired context.
-     - parameter completion: Closure called when the embedded `setOnlineIdentify` call completes, subject to throttling delays.
+     - parameter completion: Closure called when the identify completes: when the client is online, once fresh flag values for the new context are ready; when offline or backgrounded, immediately.
      */
     public func identify(context: LDContext, completion: @escaping (_ result: IdentifyResult) -> Void) {
         identifyHooked(context: context, sheddable: true, useCache: .yes, timeout: 0) { result in
@@ -371,7 +371,7 @@ public class LDClient {
 
     - parameter context: The LDContext set with the desired context.
      - parameter useCache: How to handle flag caches during identify transition.
-     - parameter completion: Closure called when the embedded `setOnlineIdentify` call completes, subject to throttling delays.
+     - parameter completion: Closure called when the identify completes: when the client is online, once fresh flag values for the new context are ready; when offline or backgrounded, immediately.
      */
     public func identify(context: LDContext, useCache: IdentifyCacheUsage, completion: @escaping (_ result: IdentifyResult) -> Void) {
         identifyHooked(context: context, sheddable: true, useCache: useCache, timeout: 0) { result in
@@ -416,7 +416,7 @@ public class LDClient {
 
     - parameter context: The LDContext set with the desired context.
      - parameter timeout: The upper time limit before the `completion` callback will be invoked.
-     - parameter completion: Closure called when the embedded `setOnlineIdentify` call completes, subject to throttling delays.
+     - parameter completion: Closure called when the identify completes: when the client is online, once fresh flag values for the new context are ready; when offline or backgrounded, immediately.
      */
     public func identify(context: LDContext, timeout: TimeInterval, completion: @escaping ((_ result: IdentifyResult) -> Void)) {
         identify(context: context, timeout: timeout, useCache: .yes, completion: completion)
@@ -433,7 +433,7 @@ public class LDClient {
     - parameter context: The LDContext set with the desired context.
      - parameter timeout: The upper time limit before the `completion` callback will be invoked.
      - parameter useCache: How to handle flag caches during identify transition.
-     - parameter completion: Closure called when the embedded `setOnlineIdentify` call completes, subject to throttling delays.
+     - parameter completion: Closure called when the identify completes: when the client is online, once fresh flag values for the new context are ready; when offline or backgrounded, immediately.
      */
     public func identify(context: LDContext, timeout: TimeInterval, useCache: IdentifyCacheUsage, completion: @escaping ((_ result: IdentifyResult) -> Void)) {
         if timeout > LDClient.longTimeoutInterval {
@@ -462,8 +462,10 @@ public class LDClient {
 
             self.context = updatedContext
             os_log("%s new context set with key: %s", log: config.logger, type: .debug, typeName(and: #function), self.context.fullyQualifiedKey())
-            let wasOnline = self.isOnline
-            self.internalSetOnline(false)
+            // Only the data source needs to come down for the swap: take the old synchronizer
+            // offline directly, as the run-mode transition does, leaving isOnline, the event
+            // reporter, and the diagnostic reporter untouched.
+            self.flagSynchronizer.isOnline = false
 
             let cachedData = self.flagCache.getCachedData(cacheKey: self.context.fullyQualifiedHashedKey(), contextHash: self.context.contextHash())
 
@@ -506,7 +508,11 @@ public class LDClient {
                 self.eventReporter.record(IdentifyEvent(context: self.context))
             }
 
-            self.internalSetOnline(wasOnline, completion: completion)
+            if self.isOnline && self.isInSupportedRunMode {
+                self.go(online: true, reasonOnlineUnavailable: "", completion: completion)
+            } else {
+                completion?()
+            }
         }
     }
 

--- a/LaunchDarkly/LaunchDarklyTests/LDClientSpec.swift
+++ b/LaunchDarkly/LaunchDarklyTests/LDClientSpec.swift
@@ -17,6 +17,7 @@ final class LDClientSpec: QuickSpec {
         startSpec()
         moveToBackgroundSpec()
         identifySpec()
+        identifyRunModeSpec()
         setOnlineSpec()
         closeSpec()
         trackEventSpec()
@@ -574,6 +575,176 @@ final class LDClientSpec: QuickSpec {
                 expect(testContext.subject.context) == newContext
                 expect(testContext.flagStoreMock.replaceStoreCallCount) == 1
                 expect(testContext.flagStoreMock.replaceStoreReceivedNewFlags) == stubFlags
+            }
+        }
+    }
+
+    // An identify while the client is backgrounded (with background updates unsupported) must not
+    // record the run-mode refusal in `isOnline`: the client should be left in the same state a
+    // plain backgrounding produces -- `isOnline` reflecting the app's request, data source down --
+    // so that returning to the foreground reconnects. Through 11.6.0 the refusal was recorded, and
+    // the client was permanently stuck offline.
+    private func identifyRunModeSpec() {
+        func backgroundedOnlineClient() -> TestContext {
+            let testContext = TestContext(startOnline: true, enableBackgroundUpdates: false)
+            testContext.start()
+            testContext.subject.setRunMode(.background)
+            return testContext
+        }
+
+        func foreground() {
+            NotificationCenter.default.post(name: SystemCapabilities.foregroundNotification!, object: self)
+        }
+
+        describe("identify while running in the background") {
+            it("keeps isOnline and leaves the data source down") {
+                let testContext = backgroundedOnlineClient()
+
+                var completed = false
+                testContext.subject.internalIdentify(newContext: LDContext.stub(), useCache: .no) {
+                    completed = true
+                }
+
+                expect(testContext.subject.isOnline) == true
+                expect(testContext.flagSynchronizerMock.isOnline) == false
+                expect(testContext.subject.eventReporter.isOnline) == true
+                expect(testContext.subject.isInitialized) == false
+                expect(completed).toEventually(beTrue())
+            }
+            it("takes the client back online at the foreground notification") {
+                let testContext = backgroundedOnlineClient()
+                testContext.subject.internalIdentify(newContext: LDContext.stub(), useCache: .no)
+
+                foreground()
+
+                expect(testContext.subject.isOnline).toEventually(beTrue())
+                expect(testContext.flagSynchronizerMock.isOnline).toEventually(beTrue())
+            }
+            it("recovers after repeated identifies while backgrounded") {
+                let testContext = backgroundedOnlineClient()
+                testContext.subject.internalIdentify(newContext: LDContext.stub(), useCache: .no)
+                testContext.subject.internalIdentify(newContext: LDContext.stub(), useCache: .no)
+                testContext.subject.internalIdentify(newContext: LDContext.stub(), useCache: .no)
+
+                foreground()
+
+                expect(testContext.subject.isOnline).toEventually(beTrue())
+                expect(testContext.flagSynchronizerMock.isOnline).toEventually(beTrue())
+            }
+            // Identify swaps the data source without taking the client offline, so the connection
+            // mode observers are not told the client went offline. Through 11.6.0 the whole client
+            // was bounced and observers saw .offline mid-swap.
+            it("does not report the client offline while identify swaps contexts") {
+                let testContext = TestContext(startOnline: true)
+                testContext.start()
+                var modes: [ConnectionInformation.ConnectionMode] = []
+                testContext.subject.observeCurrentConnectionMode(owner: self) { mode in
+                    modes.append(mode)
+                }
+
+                testContext.subject.internalIdentify(newContext: LDContext.stub(), useCache: .no)
+                testContext.onSyncComplete?(.flagCollection((FeatureFlagCollection([:]), nil)))
+
+                expect(testContext.subject.isInitialized).toEventually(beTrue(), timeout: DispatchTimeInterval.seconds(2))
+                expect(modes.filter { $0 == .offline }).to(beEmpty())
+            }
+            // The swap no longer routes through go(online: false), which latched `initialized`,
+            // so identify no longer claims initialization for a context whose flags have not
+            // arrived. Through 11.6.0 this reported initialized immediately.
+            it("does not report initialized until flags arrive for the new context") {
+                let testContext = TestContext(startOnline: true)
+                testContext.start()
+                expect(testContext.subject.isInitialized) == false
+
+                testContext.subject.internalIdentify(newContext: LDContext.stub(), useCache: .no)
+
+                expect(testContext.subject.isInitialized) == false
+
+                testContext.onSyncComplete?(.flagCollection((FeatureFlagCollection([:]), nil)))
+                expect(testContext.subject.isInitialized).toEventually(beTrue(), timeout: DispatchTimeInterval.seconds(2))
+            }
+            // Samples state in the middle of the swap, via the cache read identify performs
+            // between taking the old data source down and bringing the new one up. Through
+            // 11.6.0 the whole client was bounced, so both read false mid-swap.
+            it("keeps the client online and events flowing while identify swaps contexts") {
+                let testContext = TestContext(startOnline: true)
+                testContext.start()
+                let original = testContext.featureFlagCachingMock.getCachedDataCallback
+                var isOnlineDuringSwap: Bool?
+                var eventReporterOnlineDuringSwap: Bool?
+                testContext.featureFlagCachingMock.getCachedDataCallback = {
+                    try original?()
+                    isOnlineDuringSwap = testContext.subject.isOnline
+                    eventReporterOnlineDuringSwap = testContext.subject.eventReporter.isOnline
+                }
+
+                testContext.subject.internalIdentify(newContext: LDContext.stub(), useCache: .no)
+
+                expect(isOnlineDuringSwap) == true
+                expect(eventReporterOnlineDuringSwap) == true
+            }
+            it("recovers when the app backgrounds midway through an identify") {
+                let testContext = TestContext(startOnline: true, enableBackgroundUpdates: false)
+                testContext.start()
+                let original = testContext.featureFlagCachingMock.getCachedDataCallback
+                testContext.featureFlagCachingMock.getCachedDataCallback = {
+                    try original?()
+                    testContext.subject.setRunMode(.background)
+                }
+
+                testContext.subject.internalIdentify(newContext: LDContext.stub(), useCache: .no)
+                testContext.featureFlagCachingMock.getCachedDataCallback = original
+
+                expect(testContext.subject.isOnline) == true
+                expect(testContext.flagSynchronizerMock.isOnline) == false
+
+                NotificationCenter.default.post(name: SystemCapabilities.foregroundNotification!, object: self)
+                expect(testContext.subject.isOnline).toEventually(beTrue())
+                expect(testContext.flagSynchronizerMock.isOnline).toEventually(beTrue())
+            }
+            // The mirror image of the background-then-identify cases above: identify then
+            // background must end in the same state, so the two transitions compose in either
+            // order.
+            it("stays online with the data source down when backgrounded after an identify") {
+                let testContext = TestContext(startOnline: true, enableBackgroundUpdates: false)
+                testContext.start()
+                testContext.subject.internalIdentify(newContext: LDContext.stub(), useCache: .no)
+                expect(testContext.subject.isOnline) == true
+
+                testContext.subject.setRunMode(.background)
+
+                expect(testContext.subject.isOnline) == true
+                expect(testContext.flagSynchronizerMock.isOnline) == false
+
+                NotificationCenter.default.post(name: SystemCapabilities.foregroundNotification!, object: self)
+                expect(testContext.subject.isOnline).toEventually(beTrue())
+                expect(testContext.flagSynchronizerMock.isOnline).toEventually(beTrue())
+            }
+            // Identify brings the new data source up directly rather than through the throttled
+            // setOnline path, so a pending throttled work item can neither defer it nor discard
+            // its completion. Through 11.6.0 the restore consumed a throttle attempt.
+            it("does not involve the throttler") {
+                let testContext = TestContext(startOnline: true)
+                testContext.start()
+                testContext.throttlerMock?.runThrottledCallCount = 0
+
+                testContext.subject.internalIdentify(newContext: LDContext.stub(), useCache: .no)
+
+                expect(testContext.throttlerMock?.runThrottledCallCount) == 0
+            }
+            it("leaves a client the application set offline offline") {
+                let testContext = TestContext(startOnline: false, enableBackgroundUpdates: false)
+                testContext.start()
+                testContext.subject.setRunMode(.background)
+
+                testContext.subject.internalIdentify(newContext: LDContext.stub(), useCache: .no)
+                foreground()
+
+                // wait for the foreground transition to be fully handled, then check it did not
+                // resurrect a client the application asked to be offline
+                expect(testContext.subject.runMode).toEventually(equal(.foreground))
+                expect(testContext.subject.isOnline) == false
+                expect(testContext.flagSynchronizerMock.isOnline) == false
             }
         }
     }
@@ -1443,6 +1614,99 @@ final class LDClientSpec: QuickSpec {
 
                 testContext.subject.close()
                 expect(testContext.subject.isInitialized) == false
+            }
+
+            // MARK: SDK-3065 characterization
+            //
+            // These pin `isInitialized` behavior this branch retains from 11.6.0, so the identify
+            // change cannot alter it unnoticed.
+
+            it("becomes true when set offline before flags arrive") {
+                let testContext = TestContext(startOnline: true)
+                testContext.start()
+                expect(testContext.subject.isInitialized) == false
+
+                testContext.subject.setOnline(false)
+
+                expect(testContext.subject.isInitialized) == true
+            }
+            it("stays true after going back online without ever receiving flags") {
+                let testContext = TestContext(startOnline: true)
+                testContext.start()
+                testContext.subject.setOnline(false)
+                expect(testContext.subject.isInitialized) == true
+
+                testContext.subject.setOnline(true)
+
+                // Monotonic: the offline latch is never cleared.
+                expect(testContext.subject.isInitialized) == true
+            }
+            it("stays true when identify runs after flags arrived") {
+                let testContext = TestContext(startOnline: true)
+                testContext.start()
+                testContext.onSyncComplete?(.flagCollection((FeatureFlagCollection([:]), nil)))
+                expect(testContext.subject.isInitialized).toEventually(beTrue(), timeout: DispatchTimeInterval.seconds(2))
+
+                testContext.subject.internalIdentify(newContext: LDContext.stub(), useCache: .yes)
+
+                expect(testContext.subject.isInitialized) == true
+            }
+            it("stays true across setOnline and identify cycles once flags arrived") {
+                let testContext = TestContext(startOnline: true)
+                testContext.start()
+                testContext.onSyncComplete?(.flagCollection((FeatureFlagCollection([:]), nil)))
+                expect(testContext.subject.isInitialized).toEventually(beTrue(), timeout: DispatchTimeInterval.seconds(2))
+
+                testContext.subject.setOnline(false)
+                expect(testContext.subject.isInitialized) == true
+                testContext.subject.setOnline(true)
+                expect(testContext.subject.isInitialized) == true
+                testContext.subject.internalIdentify(newContext: LDContext.stub(), useCache: .yes)
+                expect(testContext.subject.isInitialized) == true
+            }
+            it("becomes true when setOnline(true) is refused in the background") {
+                let testContext = TestContext(startOnline: true, enableBackgroundUpdates: false)
+                testContext.start()
+                testContext.subject.setRunMode(.background)
+                expect(testContext.subject.isInitialized) == false
+
+                testContext.subject.setOnline(true)
+                expect(testContext.subject.isInitialized) == true
+
+                NotificationCenter.default.post(name: SystemCapabilities.foregroundNotification!, object: self)
+                expect(testContext.subject.isInitialized) == true
+            }
+            it("remains false across a background and foreground cycle without flags") {
+                let testContext = TestContext(startOnline: true, enableBackgroundUpdates: false)
+                testContext.start()
+                expect(testContext.subject.isInitialized) == false
+
+                testContext.subject.setRunMode(.background)
+                expect(testContext.subject.isInitialized) == false
+
+                NotificationCenter.default.post(name: SystemCapabilities.foregroundNotification!, object: self)
+                expect(testContext.subject.isInitialized) == false
+            }
+            it("becomes true when the client is unauthorized") {
+                let testContext = TestContext(startOnline: true)
+                testContext.start()
+                expect(testContext.subject.isInitialized) == false
+
+                let unauthorized = HTTPURLResponse(url: URL(string: "https://app.launchdarkly.com")!,
+                                                   statusCode: 401,
+                                                   httpVersion: nil,
+                                                   headerFields: nil)
+                testContext.onSyncComplete?(.error(.response(unauthorized)))
+
+                expect(testContext.subject.isInitialized).toEventually(beTrue(), timeout: DispatchTimeInterval.seconds(2))
+            }
+            it("becomes true when the mobile key is empty") {
+                let config = LDConfig.stub(mobileKey: "", autoEnvAttributes: .disabled, isDebugBuild: false)
+                let testContext = TestContext(newConfig: config, startOnline: true)
+                testContext.start()
+
+                expect(testContext.subject.isOnline) == false
+                expect(testContext.subject.isInitialized) == true
             }
         }
     }

--- a/LaunchDarkly/LaunchDarklyTests/LDClientSpec.swift
+++ b/LaunchDarkly/LaunchDarklyTests/LDClientSpec.swift
@@ -732,6 +732,29 @@ final class LDClientSpec: QuickSpec {
 
                 expect(testContext.throttlerMock?.runThrottledCallCount) == 0
             }
+            // When online, identify brings the new data source up via go(online: true), which
+            // registers flag observers and fires the completion only once flags for the new
+            // context arrive -- unlike the offline/backgrounded path, which completes
+            // immediately. This is the online completion path the other tests don't exercise
+            // (they call internalIdentify without a completion).
+            it("defers the identify completion until flags arrive when online, then fires once") {
+                let testContext = TestContext(startOnline: true)
+                testContext.start()
+
+                var count = 0
+                testContext.subject.internalIdentify(newContext: LDContext.stub(), useCache: .no) {
+                    count += 1
+                }
+                // Online: the completion waits for the new context's flags, so it has not fired.
+                expect(count) == 0
+
+                testContext.onSyncComplete?(.flagCollection((FeatureFlagCollection([:]), nil)))
+                expect(count).toEventually(equal(1))
+
+                // Drain any further queued observer callbacks; the completion must not fire again.
+                waitUntil { done in DispatchQueue.main.async { done() } }
+                expect(count) == 1
+            }
             it("leaves a client the application set offline offline") {
                 let testContext = TestContext(startOnline: false, enableBackgroundUpdates: false)
                 testContext.start()


### PR DESCRIPTION
## What

Calling `identify` while the app is backgrounded (where background flag updates are unsupported) left the client **permanently offline**. The run-mode refusal to reconnect was recorded as the client's online state, so returning to the foreground never brought the SDK back online — flag updates and event delivery stopped until the app was relaunched.

`identify` now swaps only the flag data source for the new context and leaves the client's online state alone — the same way a foreground/background transition already does. A backgrounded `identify` is left in the state a plain backgrounding produces and reconnects when the app returns to the foreground.

Jira: SDK-3065

## Root cause

`internalIdentify` captured `wasOnline = isOnline`, tore the whole client down with `internalSetOnline(false)`, then restored with `internalSetOnline(wasOnline)`. In the background the restore is refused by `canGoOnline` and executed as `go(online: false)`, which writes `false` into `_isOnline`. Nothing on the foreground path re-asserted the request, so the client stayed offline. Because the `isOnline` setter is the sole writer of `eventReporter.isOnline`, events stopped too.

## Fix

Inside `internalIdentify`:
- Teardown takes only the data source offline (`flagSynchronizer.isOnline = false`), as the run-mode transition already does — instead of `internalSetOnline(false)`.
- After the swap, bring the new data source up with `go(online: true)` only when `isOnline && isInSupportedRunMode`; otherwise fire the completion immediately. The client's online state is never touched by `identify`.

## Behavior changes

- `identify` no longer takes the client offline while swapping contexts, so `isOnline` does not momentarily report `false` and connection-mode observers are not notified of an offline transition during an `identify`.
- `identify`'s reconnect is no longer subject to the `setOnline` throttling delay.
- `isInitialized` is no longer reported `true` immediately after an `identify` that runs before flag values for the new context have arrived; it becomes `true` once those values arrive (or the client is offline).

These align iOS with the Android and Flutter SDKs, which treat `identify` as a data-source swap rather than an online-state transition.

## Test plan

- New `identifyRunModeSpec` and `isInitialized` characterization tests in `LDClientSpec` (12 added).
- Full iOS suite: 659 passing. Verified red against stock v11 (15 failures across exactly the new behavioral tests) and green with the fix; macOS scheme builds clean.
- Reproduced end-to-end in a sample app: a background `identify` keeps `isOnline == true` and the client returns to streaming ~3s after foregrounding — the same sequence that left 11.6.0 permanently offline.

## Deliberately out of scope

These are pre-existing on v11, unchanged by this PR, and tracked separately:
- `setOnline(true)` called while backgrounded still records the run-mode refusal (same class of bug, on the public setter rather than `identify`).
- Throttler / shedding-queue completion handling (a dropped `identify` completion can stall the identify queue; a failed flag sync never resolves an online completion).
- Stale flag-sync reports applied across a synchronizer swap (cross-context store/cache write).

## Follow-ups

- A small follow-up will add a generation guard so a superseded synchronizer's sync results are dropped rather than applied to the new context; it stacks on this branch.
- The broader online-state redesign (a recorded "desired online" state plus reconcile) is deferred to the connection-mode alignment work.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Fixes a bug where **`identify` while backgrounded** (without background updates) could leave **`LDClient` stuck offline** after foregrounding, because the old flow called `internalSetOnline(false)` then tried to restore online state and the background refusal was written into `_isOnline`.
> 
> **`internalIdentify`** now swaps contexts by taking only the **flag synchronizer** offline (`flagSynchronizer.isOnline = false`) and bringing the new data source up via **`go(online: true)`** when the client is still online and in a supported run mode; otherwise it completes immediately. **`isOnline`**, event reporting, and diagnostics are not toggled during identify.
> 
> Docs are updated to match: identify no longer implies an offline/online bounce or `setOnline` throttling; completion semantics are clarified for online vs offline/background.
> 
> **Gemfile** pins **`json` < 3.0** so Jazzy doc generation keeps working (json 3.0 dropped `quirks_mode`).
> 
> Tests add **`identifyRunModeSpec`** and **`isInitialized`** characterization coverage for background identify, foreground recovery, connection-mode observers, throttler bypass, and completion timing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce3ad2b488154db7d2570c86644068dfaf0ac453. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->